### PR TITLE
Mac compile fix

### DIFF
--- a/src/Utils/Log.h
+++ b/src/Utils/Log.h
@@ -14,6 +14,7 @@
 		#include "InworldAINdkModule.h"
 		#include "Runtime/Launch/Resources/Version.h"
 		#if ENGINE_MAJOR_VERSION > 4
+			#include <string>
 			#include <string_view>
 			namespace Inworld { using LogFormatType = std::string_view; }
 		#else


### PR DESCRIPTION
Need to include string.h for MacOS in Unreal, or complains about undefined std::basic_string