### PR TITLE
add resource to token request

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -174,6 +174,7 @@ void Inworld::ClientBase::GenerateToken(std::function<void()> GenerateTokenCallb
 		"InworldGenerateTokenTask",
 		std::make_unique<RunnableGenerateSessionToken>(
 			_ClientOptions.ServerUrl,
+			_ClientOptions.Resource,
 			_ClientOptions.ApiKey,
 			_ClientOptions.ApiSecret,
 			[this](const grpc::Status& Status, const InworldEngine::AccessToken& Token) mutable

--- a/src/Client.h
+++ b/src/Client.h
@@ -28,6 +28,7 @@ namespace Inworld
 	{
 		std::string ServerUrl;
 		std::string SceneName;
+		std::string Resource;
 		std::string ApiKey;
 		std::string ApiSecret;
 		std::string Base64;

--- a/src/RunnableCommand.cpp
+++ b/src/RunnableCommand.cpp
@@ -133,6 +133,7 @@ grpc::Status Inworld::RunnableGenerateSessionToken::RunProcess()
 {
 	InworldEngine::GenerateTokenRequest AuthRequest;
 	AuthRequest.set_key(_ApiKey);
+	AuthRequest.add_resources(_Resource);
 
 	auto& AuthCtx = UpdateContext({ {"authorization", GenerateHeader() } });
 

--- a/src/RunnableCommand.cpp
+++ b/src/RunnableCommand.cpp
@@ -133,7 +133,10 @@ grpc::Status Inworld::RunnableGenerateSessionToken::RunProcess()
 {
 	InworldEngine::GenerateTokenRequest AuthRequest;
 	AuthRequest.set_key(_ApiKey);
-	AuthRequest.add_resources(_Resource);
+	if(!_Resource.empty())
+	{
+			AuthRequest.add_resources(_Resource);
+	}
 
 	auto& AuthCtx = UpdateContext({ {"authorization", GenerateHeader() } });
 

--- a/src/RunnableCommand.h
+++ b/src/RunnableCommand.h
@@ -180,8 +180,9 @@ namespace Inworld
 	class INWORLD_EXPORT RunnableGenerateSessionToken : public RunnableRequest<InworldEngine::WorldEngine, InworldEngine::AccessToken>
 	{
 	public:
-		RunnableGenerateSessionToken(const std::string& ServerUrl, const std::string& ApiKey, const std::string& ApiSecret, std::function<void(const grpc::Status&, const InworldEngine::AccessToken&)> Callback = nullptr)
+		RunnableGenerateSessionToken(const std::string& ServerUrl, const std::string& Resource, const std::string& ApiKey, const std::string& ApiSecret, std::function<void(const grpc::Status&, const InworldEngine::AccessToken&)> Callback = nullptr)
 			: RunnableRequest(ServerUrl, Callback)
+			, _Resource(Resource)
 			, _ApiKey(ApiKey)
 			, _ApiSecret(ApiSecret)
 		{}
@@ -193,6 +194,7 @@ namespace Inworld
 	private:
 		std::string GenerateHeader() const;
 
+		std::string _Resource;
 		std::string _ApiKey;
 		std::string _ApiSecret;
 	};


### PR DESCRIPTION
For public workspaces, we need to send along the resource "workspaces/my-workspace-name" alongside the api key. Add this as a separate arg, as we cannot infer based on api key if part of a public workspace and user using own key