### PR TITLE
Change return type for extern c in Andoird

### DIFF
--- a/Example/Unity/UnityInterop.cpp
+++ b/Example/Unity/UnityInterop.cpp
@@ -77,11 +77,11 @@ void Unity_DestroyWrapper()
 	g_pWrapper = nullptr;
 }
 
-NDKUnity::SessionInfo Unity_GetSessionInfo()
+const NDKUnity::SessionInfo* Unity_GetSessionInfo()
 {	
 	if (g_pWrapper == nullptr)
-		return {};
-	return NDKUnity::SessionInfo(g_pWrapper->GetSessionInfo());
+		return nullptr;
+	return new NDKUnity::SessionInfo(g_pWrapper->GetSessionInfo());
 }
 
 void Unity_LoadScene(const char* strSceneName, NDKUnity::UnityCallback callback)
@@ -99,11 +99,11 @@ int Unity_GetAgentCount()
 	return static_cast<int>(g_pWrapper->GetAgentInfo().size());
 }
 
-NDKUnity::AgentInfo Unity_GetAgentInfo(int nIndex)
+const NDKUnity::AgentInfo* Unity_GetAgentInfo(int nIndex)
 {
 	if (g_pWrapper == nullptr || nIndex < 0 || nIndex > g_pWrapper->GetAgentInfo().size())
-		return {};
-	return NDKUnity::AgentInfo(g_pWrapper->GetAgentInfo()[nIndex]);
+		return nullptr;
+	return new NDKUnity::AgentInfo(g_pWrapper->GetAgentInfo()[nIndex]);
 }
 
 void Unity_StartSession()

--- a/Example/Unity/UnityInterop.h
+++ b/Example/Unity/UnityInterop.h
@@ -54,9 +54,9 @@ extern "C"
 	DLL_EXPORT void Unity_Hello();
 	
 #pragma region Getter
-	DLL_EXPORT NDKUnity::SessionInfo Unity_GetSessionInfo();
+	DLL_EXPORT const NDKUnity::SessionInfo* Unity_GetSessionInfo();
 	DLL_EXPORT int Unity_GetAgentCount();
-	DLL_EXPORT NDKUnity::AgentInfo Unity_GetAgentInfo(int nIndex);  // NOLINT(clang-diagnostic-return-type-c-linkage)
+	DLL_EXPORT const NDKUnity::AgentInfo* Unity_GetAgentInfo(int nIndex);  
 #pragma endregion Getter	
 
 #if __cplusplus


### PR DESCRIPTION
The extern C is required in Android, which means it cannot support return structures.

Has to use Marshal.